### PR TITLE
Updated Meetings, Ideas, and Minions Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ My solution to the Codecademy Boss Machine project.
 
 Only adding files that I touched to this repo, not the code provided by Codecademy.
 
+Required some troubleshooting of the test script, more details [here](https://discuss.codecademy.com/t/boss-machine-post-api-meetings-test-failures-fix/840420).
+
 More to be added...

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Boss Machine Project
-My solution to the Codecademy Boss Machine project.
+My solution to the Codecademy Boss Machine project. This repo only includes the files I touched, not the code provided by Codecademy.
 
-Only adding files that I touched to this repo, not the code provided by Codecademy.
+## Project Overview
+[From Codecademy](https://www.codecademy.com/journeys/back-end-engineer/paths/becj-22-back-end-development/tracks/becp-22-build-a-back-end-with-express-js/modules/wdcp-22-boss-machine-0c8ce2d6-418b-487f-857f-49771b21894a/informationals/bapi-p4-boss-machine):
+> In this project, you will create an entire API to serve information to a Boss Machine, a unique management application for today’s most accomplished (evil) entrepreneurs. You will create routes to manage your ‘minions’, your brilliant ‘million dollar ideas’, and to handle all the annoying meetings that keep getting added to your busy schedule.
 
-Required some troubleshooting of the test script, more details [here](https://discuss.codecademy.com/t/boss-machine-post-api-meetings-test-failures-fix/840420).
+## Learning Goals:
+- Practice using **Node.JS**
+- Practices creating routers and writing routes in **Express.JS**
+- Practice writing **factory functions**:
+  - This wasn't in the spec but the callback functions for GET, POST, PUT, and DELETE routes were the same across the /api/meetings, /api/minions, and /api/ideas routes, so I thought it would be a good oppourtunity to practice this.
 
-More to be added...
+## Roadblocks:
+Some tests in the test file provided by CodeAcademy required some troubleshooting and updating the test script: more details [here](https://discuss.codecademy.com/t/boss-machine-post-api-meetings-test-failures-fix/840420).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ My solution to the Codecademy Boss Machine project. This repo only includes the 
 
 ## Learning Goals:
 - Practice using **Node.JS**
-- Practices creating routers and writing routes in **Express.JS**
+- Practice creating routers and writing routes in **Express.JS**
 - Practice writing **factory functions**:
   - This wasn't in the spec but the callback functions for GET, POST, PUT, and DELETE routes were the same across the /api/meetings, /api/minions, and /api/ideas routes, so I thought it would be a good oppourtunity to practice this.
 

--- a/server/api.js
+++ b/server/api.js
@@ -3,7 +3,7 @@ const apiRouter = express.Router();
 
 // Import minionsRouter and use it for /api/minions path
 const minionsRouter = require('./minions.js');
-apiRouter.use('/api/minions', minionsRouter);
+apiRouter.use('/minions', minionsRouter);
 
 // remember to import and app.use all new routers
 

--- a/server/api.js
+++ b/server/api.js
@@ -5,7 +5,10 @@ const apiRouter = express.Router();
 const minionsRouter = require('./minions.js');
 apiRouter.use('/minions', minionsRouter);
 
-// remember to import and app.use all new routers
+// Import ideasRouter and use it for /api/ideas path
+const ideasRouter = require('./ideas.js');
+apiRouter.use('/ideas', ideasRouter);
 
+// remember to import and app.use all new routers
 
 module.exports = apiRouter;

--- a/server/api.js
+++ b/server/api.js
@@ -1,14 +1,16 @@
 const express = require('express');
 const apiRouter = express.Router();
 
-// Import minionsRouter and use it for /api/minions path
+// Import minionsRouter and use it for /api/minions
 const minionsRouter = require('./minions.js');
 apiRouter.use('/minions', minionsRouter);
 
-// Import ideasRouter and use it for /api/ideas path
+// Import ideasRouter and use it for /api/ideas
 const ideasRouter = require('./ideas.js');
 apiRouter.use('/ideas', ideasRouter);
 
-// remember to import and app.use all new routers
+// Import meetingsRouter and use it for /api/meetings
+const meetingsRouter = require('./meetings.js');
+apiRouter.use('/meetings', meetingsRouter);
 
 module.exports = apiRouter;

--- a/server/checkMillionDollarIdea.js
+++ b/server/checkMillionDollarIdea.js
@@ -1,0 +1,18 @@
+//`checkMillionDollarIdea` that will come in handy in some /api/ideas routes. 
+// Write this function in the **server/checkMillionDollarIdea.js** file. 
+// This function will make sure that any new or updated ideas are still worth at least one million dollars! 
+// The total value of an idea is the product of its `numWeeks` and `weeklyRevenue` properties.
+
+const checkMillionDollarIdea = (req, res, next) => {
+    const newIdeaPayload = req.body;
+    if (newIdeaPayload.numWeeks && newIdeaPayload.weeklyRevenue) {
+        newIdeaPayload.value = Number(newIdeaPayload.numWeeks) * Number(newIdeaPayload.weeklyRevenue);
+        if (newIdeaPayload.value >= 1000000) return next();
+        return next(new Error('Please enter an idea worth greater than or equal to $1MM.'));
+    } else {
+        return next(new Error('Please enter a valid numWeeks and weeklyRevenue for the idea.'));
+    }
+};
+
+// Leave this exports assignment so that the function can be used elsewhere
+module.exports = checkMillionDollarIdea;

--- a/server/checkMillionDollarIdea.js
+++ b/server/checkMillionDollarIdea.js
@@ -6,8 +6,8 @@
 const checkMillionDollarIdea = (req, res, next) => {
     const newIdeaPayload = req.body;
     if (newIdeaPayload.numWeeks && newIdeaPayload.weeklyRevenue) {
-        newIdeaPayload.value = Number(newIdeaPayload.numWeeks) * Number(newIdeaPayload.weeklyRevenue);
-        if (newIdeaPayload.value >= 1000000) return next();
+        const ideaValue = Number(newIdeaPayload.numWeeks) * Number(newIdeaPayload.weeklyRevenue);
+        if (ideaValue >= 1000000) return next();
         return next(new Error('Please enter an idea worth greater than or equal to $1MM.'));
     } else {
         return next(new Error('Please enter a valid numWeeks and weeklyRevenue for the idea.'));

--- a/server/checkMillionDollarIdea.js
+++ b/server/checkMillionDollarIdea.js
@@ -5,12 +5,17 @@
 
 const checkMillionDollarIdea = (req, res, next) => {
     const newIdeaPayload = req.body;
-    if (newIdeaPayload.numWeeks && newIdeaPayload.weeklyRevenue) {
+    if (newIdeaPayload.numWeeks 
+        && newIdeaPayload.weeklyRevenue 
+        && typeof Number(newIdeaPayload.numWeeks) !== NaN
+        && typeof Number(newIdeaPayload.weeklyRevenue) !== NaN) {
         const ideaValue = Number(newIdeaPayload.numWeeks) * Number(newIdeaPayload.weeklyRevenue);
         if (ideaValue >= 1000000) return next();
-        return next(new Error('Please enter an idea worth greater than or equal to $1MM.'));
+        const valueError = new Error('Please enter an idea worth greater than or equal to $1MM.');
+        res.status(400).send(valueError.message);
     } else {
-        return next(new Error('Please enter a valid numWeeks and weeklyRevenue for the idea.'));
+        const validationError = new Error('Please enter valid numbers for numWeeks and weeklyRevenue for the idea.');
+        res.status(400).send(validationError.message);
     }
 };
 

--- a/server/generic-error-handler.js
+++ b/server/generic-error-handler.js
@@ -1,0 +1,5 @@
+const genericErrorHandler = (err, req, res, next) => {
+    res.status(404).send(err.message);
+  };
+
+module.exports = genericErrorHandler;

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -1,16 +1,16 @@
 const express = require('express');
 
-// Create minionsRouter
+// Create ideasRouter
 const ideasRouter = express.Router();
 
 // Create a new stream to write to file in this directory
 const fs = require('fs');
 const path = require('path');
-const minionLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'minion-logs.txt'), { flags: 'a' });
+const ideasLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'ideas-logs.txt'));
 
 // Require in morgan
 const morgan = require('morgan');
-minionsRouter.use(morgan('common', { stream: minionLogStream }));
+ideasRouter.use(morgan('common', { stream: ideasLogStream }));
 
 // Import database helper functions
 const { getAllFromDatabase
@@ -28,8 +28,8 @@ const { getAllFromDatabase
 // DELETE /api/ideas/:ideaId to delete a single idea by id.
 
 // Generic error handler
-minionsRouter.use((err, req, res, next) => {
-    minionLogStream.write(`${err.name}: ${err.message} \n${err.fileName}: ${err.lineNumber} \n`);
+ideasRouter.use((err, req, res, next) => {
+    ideasLogStream.write(`${err.name}: ${err.message} \n${err.fileName}: ${err.lineNumber} \n`);
     res.status(404).send(err.message);
   });
 

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -1,0 +1,36 @@
+const express = require('express');
+
+// Create minionsRouter
+const ideasRouter = express.Router();
+
+// Create a new stream to write to file in this directory
+const fs = require('fs');
+const path = require('path');
+const minionLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'minion-logs.txt'), { flags: 'a' });
+
+// Require in morgan
+const morgan = require('morgan');
+minionsRouter.use(morgan('common', { stream: minionLogStream }));
+
+// Import database helper functions
+const { getAllFromDatabase
+    , getFromDatabaseById
+    , addToDatabase
+    , updateInstanceInDatabase
+    , deleteFromDatabasebyId
+    , deleteAllFromDatabase } 
+    = require('./db.js');
+
+// GET /api/ideas to get an array of all ideas.
+// POST /api/ideas to create a new idea and save it to the database.
+// GET /api/ideas/:ideaId to get a single idea by id.
+// PUT /api/ideas/:ideaId to update a single idea by id.
+// DELETE /api/ideas/:ideaId to delete a single idea by id.
+
+// Generic error handler
+minionsRouter.use((err, req, res, next) => {
+    minionLogStream.write(`${err.name}: ${err.message} \n${err.fileName}: ${err.lineNumber} \n`);
+    res.status(404).send(err.message);
+  });
+
+module.exports = ideasRouter;

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -32,6 +32,7 @@ ideasRouter.get('/', (req, res, next) => {
 
 // POST /api/ideas to create a new idea and save it to the database.
 // Schema & data types are validated by addToDatabase() function.
+// Use checkMillionDollarIdea for value validation
 ideasRouter.post('/', checkMillionDollarIdea, (req, res, next) => {
     const newIdeaPayload = req.body;
     try {
@@ -43,12 +44,43 @@ ideasRouter.post('/', checkMillionDollarIdea, (req, res, next) => {
     }
   });
 
+// Middleware function to check if provided ideasId exists  
+  ideasRouter.param('ideaId', (req, res, next, id) => {
+    const requestedIdea = getFromDatabaseById('ideas', id);
+    if (requestedIdea) {
+      req.ideaId = id;
+      req.requestedIdea = requestedIdea;
+      next();
+    } else {
+      next(new Error('Please enter a valid idea id.'));
+    }
+  }); 
+
 // GET /api/ideas/:ideaId to get a single idea by id.
+ideasRouter.get('/:ideaId', (req, res, next) => { 
+    res.send(req.requestedIdea);
+  });
 
 // PUT /api/ideas/:ideaId to update a single idea by id.
-// use checkMillionDollarIdea
+// Use checkMillionDollarIdea for value validation
+ideasRouter.put('/:ideaId', checkMillionDollarIdea, (req, res, next) => {
+    try {
+      const updatedIdea = updateInstanceInDatabase('ideas', req.body);
+      res.send(updatedIdea);
+    } catch(err){
+      return next(err);
+    }
+  });
 
 // DELETE /api/ideas/:ideaId to delete a single idea by id.
+ideasRouter.delete('/:ideaId', (req, res, next) => {
+    const deletedIdea = deleteFromDatabasebyId('ideas', req.ideaId);
+    if (deletedIdea) {
+      res.status(204).send();
+    } else {
+      next(new Error('Please enter a valid ideaId'));
+    }
+  });
 
 // Generic error handler
 ideasRouter.use((err, req, res, next) => {

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -21,10 +21,33 @@ const { getAllFromDatabase
     , deleteAllFromDatabase } 
     = require('./db.js');
 
+// Import checkMillionDollarIdea middleware function
+const checkMillionDollarIdea = require('./checkMillionDollarIdea.js');
+
 // GET /api/ideas to get an array of all ideas.
+ideasRouter.get('/', (req, res, next) => {
+    const ideasArray = getAllFromDatabase('ideas');
+    res.send(ideasArray);
+  });
+
 // POST /api/ideas to create a new idea and save it to the database.
+// Schema & data types are validated by addToDatabase() function.
+ideasRouter.post('/', checkMillionDollarIdea, (req, res, next) => {
+    const newIdeaPayload = req.body;
+    try {
+      const newIdea = addToDatabase('ideas', newIdeaPayload);
+      ideasLogStream.write(`newIdea: ${JSON.stringify(newIdea)} \n`);
+      res.status(201).send(newIdea);
+    } catch(err) {
+      return next(err);
+    }
+  });
+
 // GET /api/ideas/:ideaId to get a single idea by id.
+
 // PUT /api/ideas/:ideaId to update a single idea by id.
+// use checkMillionDollarIdea
+
 // DELETE /api/ideas/:ideaId to delete a single idea by id.
 
 // Generic error handler

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -21,14 +21,14 @@ const { getAllFromDatabase
     , deleteAllFromDatabase } 
     = require('./db.js');
 
+// Import route factories
+const { getAllFactory } = require('./route-factories.js');
+
 // Import checkMillionDollarIdea middleware function
 const checkMillionDollarIdea = require('./checkMillionDollarIdea.js');
 
 // GET /api/ideas to get an array of all ideas.
-ideasRouter.get('/', (req, res, next) => {
-    const ideasArray = getAllFromDatabase('ideas');
-    res.send(ideasArray);
-  });
+ideasRouter.get('/', getAllFactory('ideas'));
 
 // POST /api/ideas to create a new idea and save it to the database.
 // Schema & data types are validated by addToDatabase() function.

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -12,17 +12,13 @@ const ideasLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'ideas-
 const morgan = require('morgan');
 ideasRouter.use(morgan('common', { stream: ideasLogStream }));
 
-// Import database helper functions
-const { getAllFromDatabase
-    , getFromDatabaseById
-    , addToDatabase
-    , updateInstanceInDatabase
-    , deleteFromDatabasebyId
-    , deleteAllFromDatabase } 
-    = require('./db.js');
-
 // Import route factories
-const { getAllFactory } = require('./route-factories.js');
+const { getAllFactory
+    , postFactory
+    , checkIfValidItem 
+    , putFactory 
+    , deleteFactory } 
+    = require('./route-factories.js');
 
 // Import checkMillionDollarIdea middleware function
 const checkMillionDollarIdea = require('./checkMillionDollarIdea.js');
@@ -33,59 +29,25 @@ ideasRouter.get('/', getAllFactory('ideas'));
 // POST /api/ideas to create a new idea and save it to the database.
 // Schema & data types are validated by addToDatabase() function.
 // Use checkMillionDollarIdea for value validation
-ideasRouter.post('/', checkMillionDollarIdea, (req, res, next) => {
-    const newIdeaPayload = req.body;
-    try {
-      const newIdea = addToDatabase('ideas', newIdeaPayload);
-      ideasLogStream.write(`newIdea: ${JSON.stringify(newIdea)} \n`);
-      res.status(201).send(newIdea);
-    } catch(err) {
-      return next(err);
-    }
-  });
+ideasRouter.post('/', checkMillionDollarIdea, postFactory('ideas'));
 
 // Middleware function to check if provided ideasId exists  
-  ideasRouter.param('ideaId', (req, res, next, id) => {
-    const requestedIdea = getFromDatabaseById('ideas', id);
-    if (requestedIdea) {
-      req.ideaId = id;
-      req.requestedIdea = requestedIdea;
-      next();
-    } else {
-      next(new Error('Please enter a valid idea id.'));
-    }
-  }); 
+ideasRouter.param('ideaId', checkIfValidItem('ideas')); 
 
 // GET /api/ideas/:ideaId to get a single idea by id.
 ideasRouter.get('/:ideaId', (req, res, next) => { 
-    res.send(req.requestedIdea);
+    res.send(req.requestedItem);
   });
 
 // PUT /api/ideas/:ideaId to update a single idea by id.
 // Use checkMillionDollarIdea for value validation
-ideasRouter.put('/:ideaId', checkMillionDollarIdea, (req, res, next) => {
-    try {
-      const updatedIdea = updateInstanceInDatabase('ideas', req.body);
-      res.send(updatedIdea);
-    } catch(err){
-      return next(err);
-    }
-  });
+ideasRouter.put('/:ideaId', checkMillionDollarIdea, putFactory('ideas'));
 
 // DELETE /api/ideas/:ideaId to delete a single idea by id.
-ideasRouter.delete('/:ideaId', (req, res, next) => {
-    const deletedIdea = deleteFromDatabasebyId('ideas', req.ideaId);
-    if (deletedIdea) {
-      res.status(204).send();
-    } else {
-      next(new Error('Please enter a valid ideaId'));
-    }
-  });
+ideasRouter.delete('/:ideaId', deleteFactory('ideas'));
 
 // Generic error handler
-ideasRouter.use((err, req, res, next) => {
-    ideasLogStream.write(`${err.name}: ${err.message} \n${err.fileName}: ${err.lineNumber} \n`);
-    res.status(404).send(err.message);
-  });
+const genericErrorHandler = require('./generic-error-handler.js');
+ideasRouter.use(genericErrorHandler);
 
 module.exports = ideasRouter;

--- a/server/ideas.js
+++ b/server/ideas.js
@@ -50,4 +50,5 @@ ideasRouter.delete('/:ideaId', deleteFactory('ideas'));
 const genericErrorHandler = require('./generic-error-handler.js');
 ideasRouter.use(genericErrorHandler);
 
+// Export the router as a module
 module.exports = ideasRouter;

--- a/server/meetings.js
+++ b/server/meetings.js
@@ -1,0 +1,32 @@
+const express = require('express');
+
+// Create meetingsRouter
+const meetingsRouter = express.Router();
+
+// Create a new stream to write to file in this directory
+const fs = require('fs');
+const path = require('path');
+const meetingsLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'meetings-logs.txt'));
+
+// Require in morgan
+const morgan = require('morgan');
+meetingsRouter.use(morgan('common', { stream: meetingsLogStream }));
+
+// Import route factories
+const { getAllFactory
+    , postFactory
+    , checkIfValidItem 
+    , putFactory 
+    , deleteFactory } 
+    = require('./route-factories.js');
+
+// GET /api/meetings to get an array of all meetings.
+meetingsRouter.get('/', getAllFactory('meetings'));
+
+// POST /api/meetings to create a new meeting and save it to the database.
+meetingsRouter.post('/', postFactory('meetings'));
+
+// DELETE /api/meetings to delete _all_ meetings from the database.
+meetingsRouter.delete('/', deleteFactory('meetings', true));
+
+module.exports = meetingsRouter;

--- a/server/meetings.js
+++ b/server/meetings.js
@@ -15,8 +15,6 @@ meetingsRouter.use(morgan('common', { stream: meetingsLogStream }));
 // Import route factories
 const { getAllFactory
     , postFactory
-    , checkIfValidItem 
-    , putFactory 
     , deleteFactory } 
     = require('./route-factories.js');
 
@@ -29,4 +27,9 @@ meetingsRouter.post('/', postFactory('meetings'));
 // DELETE /api/meetings to delete _all_ meetings from the database.
 meetingsRouter.delete('/', deleteFactory('meetings', true));
 
+// Generic error handler
+const genericErrorHandler = require('./generic-error-handler.js');
+meetingsRouter.use(genericErrorHandler);
+
+// Export the router as a module
 module.exports = meetingsRouter;

--- a/server/minions.js
+++ b/server/minions.js
@@ -45,4 +45,5 @@ minionsRouter.delete('/:minionId', deleteFactory('minions'));
 const genericErrorHandler = require('./generic-error-handler.js');
 minionsRouter.use(genericErrorHandler);
 
+// Export the router as a module
 module.exports = minionsRouter;

--- a/server/minions.js
+++ b/server/minions.js
@@ -21,11 +21,11 @@ const { getAllFromDatabase
     , deleteAllFromDatabase } 
     = require('./db.js');
 
+// Import route factories
+const { getAllFactory } = require('./route-factories.js');
+
 // GET /api/minions to get an array of all minions.
-minionsRouter.get('/', (req, res, next) => {
-  const minionsArray = getAllFromDatabase('minions');
-  res.send(minionsArray);
-});
+minionsRouter.get('/', getAllFactory('minions'));
 
 // POST /api/minions to create a new minion and save it to the database.
 // Schema & data types are validated by addToDatabase() function.

--- a/server/minions.js
+++ b/server/minions.js
@@ -12,46 +12,23 @@ const minionLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'minio
 const morgan = require('morgan');
 minionsRouter.use(morgan('common', { stream: minionLogStream }));
 
-// Import database helper functions
-const { getAllFromDatabase
-    , getFromDatabaseById
-    , addToDatabase
-    , updateInstanceInDatabase
-    , deleteFromDatabasebyId
-    , deleteAllFromDatabase } 
-    = require('./db.js');
-
 // Import route factories
-const { getAllFactory } = require('./route-factories.js');
+const { getAllFactory
+  , postFactory
+  , checkIfValidItem 
+  , putFactory 
+  , deleteFactory } 
+  = require('./route-factories.js');
 
 // GET /api/minions to get an array of all minions.
 minionsRouter.get('/', getAllFactory('minions'));
 
 // POST /api/minions to create a new minion and save it to the database.
 // Schema & data types are validated by addToDatabase() function.
-minionsRouter.post('/', (req, res, next) => {
-  const newMinionPayload = req.body;
-  minionLogStream.write(`newMinionPayload: ${JSON.stringify(newMinionPayload)} \n`);
-  try {
-    const newMinion = addToDatabase('minions', newMinionPayload);
-    minionLogStream.write(`newMinion: ${JSON.stringify(newMinion)} \n`);
-    res.status(201).send(newMinion);
-  } catch(err) {
-    return next(err);
-  }
-});
+minionsRouter.post('/', postFactory('minions'));
 
 // Middleware function to check if provided minionId exists and throw an error if not
-minionsRouter.param('minionId', (req, res, next, id) => {
-  const requestedMinion = getFromDatabaseById('minions', id);
-  if (requestedMinion) {
-    req.minionId = id;
-    req.requestedMinion = requestedMinion;
-    next();
-  } else {
-    next(new Error('Please enter a valid minion id.'));
-  }
-}); 
+minionsRouter.param('minionId', checkIfValidItem('minions')); 
 
 // GET /api/minions/:minionId to get a single minion by id.
 minionsRouter.get('/:minionId', (req, res, next) => { 
@@ -59,29 +36,13 @@ minionsRouter.get('/:minionId', (req, res, next) => {
 });
 
 // PUT /api/minions/:minionId to update a single minion by id.
-minionsRouter.put('/:minionId', (req, res, next) => {
-  try {
-    const updatedMinion = updateInstanceInDatabase('minions', req.body);
-    res.send(updatedMinion);
-  } catch(err){
-    return next(err);
-  }
-});
+minionsRouter.put('/:minionId', putFactory('minions'));
 
 // DELETE /api/minions/:minionId to delete a single minion by id.
-minionsRouter.delete('/:minionId', (req, res, next) => {
-  const deletedMinion = deleteFromDatabasebyId('minions', req.minionId);
-  if (deletedMinion) {
-    res.status(204).send();
-  } else {
-    next(new Error('Please enter a valid minionId'));
-  }
-});
+minionsRouter.delete('/:minionId', deleteFactory('minions'));
 
 // Generic error handler
-minionsRouter.use((err, req, res, next) => {
-  minionLogStream.write(`${err.name}: ${err.message} \n${err.fileName}: ${err.lineNumber} \n`);
-  res.status(404).send(err.message);
-});
+const genericErrorHandler = require('./generic-error-handler.js');
+minionsRouter.use(genericErrorHandler);
 
 module.exports = minionsRouter;

--- a/server/minions.js
+++ b/server/minions.js
@@ -32,7 +32,7 @@ minionsRouter.param('minionId', checkIfValidItem('minions'));
 
 // GET /api/minions/:minionId to get a single minion by id.
 minionsRouter.get('/:minionId', (req, res, next) => { 
-  res.send(req.requestedMinion);
+  res.send(req.requestedItem);
 });
 
 // PUT /api/minions/:minionId to update a single minion by id.

--- a/server/route-factories.js
+++ b/server/route-factories.js
@@ -41,10 +41,10 @@ function postFactory(type) {
         const postNewItem = (req, res, next) => {
             const newItemPayload = req.body;
             try {
-            const newItem = addToDatabase(type, newItemPayload);
-            res.status(201).send(newItem);
+                const newItem = addToDatabase(type, newItemPayload);
+                res.status(201).send(newItem);
             } catch(err) {
-            return next(err);
+                return next(err);
             }
         };
         return postNewItem;
@@ -92,12 +92,10 @@ function putFactory (type) {
 }
 
 // DELETE factory
-function deleteFactory (type) {
-    if (isValidType(type)) {
+function deleteFactory (type, deleteAll) {
+    if (isValidType(type) && deleteAll !== true) {
         const deleteItem = (req, res, next) => {
-            factoryLogStream.write('Made it into deleteFactory function. \n');
             const deletedItem = deleteFromDatabasebyId(type, req.requestedItemId);
-            factoryLogStream.write(`deletedItem: ${deletedItem} \n`);
             if (deletedItem) {
               res.status(204).send();
             } else {
@@ -105,7 +103,18 @@ function deleteFactory (type) {
             }
           };
         return deleteItem;
-    } else {
+    } else if (isValidType(type) && deleteAll === true) {
+        const deleteAllItems = (req, res, next) => {
+            const deletedArray = deleteAllFromDatabase(type);
+            if (deletedArray) {
+              res.status(204).send();
+            } else {
+              next(new Error('Delete failed for some reason. Please try again.'));
+            }
+          };
+        return deleteAllItems;        
+    }
+    else {
         return(new Error('Please provide a valid type'));
     }
 }

--- a/server/route-factories.js
+++ b/server/route-factories.js
@@ -13,16 +13,16 @@ const fs = require('fs');
 const path = require('path');
 const factoryLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'factory-logs.txt'));
 
-// Require in morgan
-const morgan = require('morgan');
-
-// Valid types array
+// isValidType take a `type` as input and
+// checks if it is one of valid "types" accepted by the DB
+// returns true if so, false if not
 function isValidType(type) {
     const validTypes = ['minions', 'ideas', 'meetings', 'work'];
     return validTypes.includes(type);
 }
 
-// GET all factory
+// getAllFactory, given an input `type` 
+// returns a callback function that gets all items in the DB 
 function getAllFactory(type) {
     if (isValidType(type)) {
         const getAllItems = (req, res, next) => {
@@ -35,7 +35,8 @@ function getAllFactory(type) {
     }
 }
 
-// POST factory
+// postFactory, given an input `type` 
+// returns a callback function that creates a new item in the DB
 function postFactory(type) {
     if (isValidType(type)) {
         const postNewItem = (req, res, next) => {
@@ -53,14 +54,14 @@ function postFactory(type) {
     }
 }
 
-// checkIfValidItems factory
+// checkIfValidItems factory, given a valid `type`
+// returns a middleware function that checks the DB 
+// to see if an item with the provided id exists
 function checkIfValidItem (type) {
     if (isValidType(type)) {
         const isValidItem = (req, res, next, id) => {
             const requestedItem = getFromDatabaseById(type, id);
-            factoryLogStream.write(`JSON.stringify(requestedItem): ${JSON.stringify(requestedItem)} \n`);
             if (requestedItem) {
-              factoryLogStream.write('Made it into the requestedItem if statement. \n');
               req.requestedItemId = id;
               req.requestedItem = requestedItem;
               next();
@@ -74,7 +75,8 @@ function checkIfValidItem (type) {
     }  
 }
 
-// PUT factory
+// PUT factory, given an input `type`
+// returns a callback function that creates a new item in the DB
 function putFactory (type) {
     if (isValidType(type)) {
         const putItem = (req, res, next) => {
@@ -91,7 +93,10 @@ function putFactory (type) {
     }  
 }
 
-// DELETE factory
+// DELETE factory, given an input `type`
+// returns a callback function that deletes an item from the DB
+// optional parameter deleteAll: if true, creates a callback function that
+// deletes all items from the DB
 function deleteFactory (type, deleteAll) {
     if (isValidType(type) && deleteAll !== true) {
         const deleteItem = (req, res, next) => {
@@ -119,6 +124,7 @@ function deleteFactory (type, deleteAll) {
     }
 }
 
+// Export the factory functions as modules
 module.exports.getAllFactory = getAllFactory;
 module.exports.postFactory = postFactory;
 module.exports.checkIfValidItem = checkIfValidItem;

--- a/server/route-factories.js
+++ b/server/route-factories.js
@@ -15,10 +15,15 @@ const factoryLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'fact
 // Require in morgan
 const morgan = require('morgan');
 
+// Valid types array
+function isValidType(type) {
+    const validTypes = ['minions', 'ideas', 'meetings', 'work'];
+    return validTypes.includes(type);
+}
+
 // GET all factory
 function getAllFactory(type) {
-    const validTypes = ['minions', 'ideas', 'meetings', 'work'];
-    if (validTypes.includes(type)) {
+    if (isValidType(type)) {
         const getAllItems = (req, res, next) => {
             const allItemsArray = getAllFromDatabase(type);
             res.send(allItemsArray);
@@ -29,4 +34,83 @@ function getAllFactory(type) {
     }
 }
 
+// POST factory
+function postFactory(type) {
+    if (isValidType(type)) {
+        const postNewItem = (req, res, next) => {
+            const newItemPayload = req.body;
+            try {
+            const newItem = addToDatabase(type, newItemPayload);
+            res.status(201).send(newItem);
+            } catch(err) {
+            return next(err);
+            }
+        };
+        return postNewItem;
+    } else {
+        return(new Error('Please provide a valid type'));
+    }
+}
+
+// checkIfValidItems factory
+function checkIfValidItem (type) {
+    if (isValidType(type)) {
+        const isValidItem = (req, res, next, id) => {
+            const requestedItem = getFromDatabaseById(type, id);
+            factoryLogStream.write(`JSON.stringify(requestedItem): ${JSON.stringify(requestedItem)} \n`);
+            if (requestedItem) {
+              factoryLogStream.write('Made it into the requestedItem if statement. \n');
+              req.requestedItemId = id;
+              req.requestedItem = requestedItem;
+              next();
+            } else {
+              next(new Error('Please enter a valid idea id.'));
+            }
+          };
+        return isValidItem;
+    } else {
+        return(new Error('Please provide a valid type'));
+    }  
+}
+
+// PUT factory
+function putFactory (type) {
+    if (isValidType(type)) {
+        const putItem = (req, res, next) => {
+            try {
+              const updatedIdea = updateInstanceInDatabase(type, req.body);
+              res.send(updatedIdea);
+            } catch(err){
+              return next(err);
+            }
+          };
+        return putItem;
+    } else {
+        return(new Error('Please provide a valid type'));
+    }  
+}
+
+// DELETE factory
+function deleteFactory (type) {
+    if (isValidType(type)) {
+        const deleteItem = (req, res, next) => {
+            factoryLogStream.write('Made it into deleteFactory function. \n');
+            const deletedItem = deleteFromDatabasebyId(type, req.requestedItemId);
+            factoryLogStream.write(`deletedItem: ${deletedItem} \n`);
+            if (deletedItem) {
+              res.status(204).send();
+            } else {
+              next(new Error('Please enter a valid itemId'));
+            }
+          };
+        return deleteItem;
+    } else {
+        return(new Error('Please provide a valid type'));
+    }
+}
+
 module.exports.getAllFactory = getAllFactory;
+module.exports.postFactory = postFactory;
+module.exports.checkIfValidItem = checkIfValidItem;
+module.exports.putFactory = putFactory;
+module.exports.deleteFactory = deleteFactory;

--- a/server/route-factories.js
+++ b/server/route-factories.js
@@ -1,0 +1,32 @@
+// Import database helper functions
+const { getAllFromDatabase
+    , getFromDatabaseById
+    , addToDatabase
+    , updateInstanceInDatabase
+    , deleteFromDatabasebyId
+    , deleteAllFromDatabase } 
+    = require('./db.js');
+
+// Create a new stream to write to file in this directory
+const fs = require('fs');
+const path = require('path');
+const factoryLogStream = fs.createWriteStream(path.join(__dirname, 'logs', 'factory-logs.txt'));
+
+// Require in morgan
+const morgan = require('morgan');
+
+// GET all factory
+function getAllFactory(type) {
+    const validTypes = ['minions', 'ideas', 'meetings', 'work'];
+    if (validTypes.includes(type)) {
+        const getAllItems = (req, res, next) => {
+            const allItemsArray = getAllFromDatabase(type);
+            res.send(allItemsArray);
+        };
+        return getAllItems;
+    } else {
+        return(new Error('Please provide a valid type'));
+    }
+}
+
+module.exports.getAllFactory = getAllFactory;

--- a/server/route-factories.js
+++ b/server/route-factories.js
@@ -1,3 +1,4 @@
+// TO-DO: improve comments
 // Import database helper functions
 const { getAllFromDatabase
     , getFromDatabaseById


### PR DESCRIPTION
I updated the meetings, ideas, and minions routers. All APIs working as expected; tested via the integration test script and the front-end.

I created factory functions in server/route-factories.js for the callback functions for the GET, POST, PUT, DELETE routes and refactored the minions and ideas routers to use these. The meetings router was originally written using the factory functions.

All routes:
- `/api/minions`
    - GET /api/minions to get an array of all minions.
    - POST /api/minions to create a new minion and save it to the database.
    - GET /api/minions/:minionId to get a single minion by id.
    - PUT /api/minions/:minionId to update a single minion by id.
    - DELETE /api/minions/:minionId to delete a single minion by id.
- `/api/ideas`
    - GET /api/ideas to get an array of all ideas.
    - POST /api/ideas to create a new idea and save it to the database.
    - GET /api/ideas/:ideaId to get a single idea by id.
    - PUT /api/ideas/:ideaId to update a single idea by id.
    - DELETE /api/ideas/:ideaId to delete a single idea by id.
- `/api/meetings`
    - GET /api/meetings to get an array of all meetings.
    - POST /api/meetings to create a new meeting and save it to the database.
    - DELETE /api/meetings to delete _all_ meetings from the database.